### PR TITLE
Added code to throw a nicer error when there aren't any episodes found

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,7 +254,12 @@ func getEpisodeBatches(url string, minEp, maxEp, epsPerBatch, delayMs int) []Epi
 		// assume viewing set of episodes
 		println("scanning all pages to get all episode links")
 		allEpisodeLinks := getAllEpisodeLinks(url, delayMs)
-		println(fmt.Sprintf("found %d total episodes", len(allEpisodeLinks)))
+		if len(allEpisodeLinks) > 0 {
+			println(fmt.Sprintf("found %d total episodes", len(allEpisodeLinks)))
+		} else {
+			println("no episodes found; aborting")
+			os.Exit(1)
+		}
 
 		var desiredEpisodeLinks []string
 		for _, episodeLink := range allEpisodeLinks {


### PR DESCRIPTION
I fixed a bug where if the url was incorrect, webtoon-dl would panic... This seems a little bit unnecessary in my opinion, the program should gracefully exit if this situation is encountered. The best way to explain what I mean is with an example:

BEFORE:
```
~/Builds/webtoon-dl [2] $ ./webtoon-dl https://example.com
scanning all pages to get all episode links
found 0 total episodes
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.getEpisodeBatches({0x7ffcbe741c81, 0x13}, 0x0, 0x7fffffffffffffff, 0xa, 0x3e8)
	/Builds/webtoon-dl/main.go:266 +0x7e5
main.main()
	/Builds/webtoon-dl/main.go:463 +0xec
```

AFTER:
```
~/Builds/webtoon-dl [2] $ ./webtoon-dl https://example.com
scanning all pages to get all episode links
no episodes found; aborting
```